### PR TITLE
Use "VK_EXT_load_store_op_none" instead of "VK_KHR_load_store_op_none". Do not run Workflows on every push.

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,6 +1,6 @@
 name: Artifacts (Package)
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   artifacts-mingw-w64:

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -1,6 +1,6 @@
 name: Test Builds on Windows
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   build-set-windows:

--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -75,7 +75,7 @@
         },
         "dxvk_common_optional": {
             "extensions": {
-                "VK_KHR_load_store_op_none": 1,
+                "VK_EXT_load_store_op_none": 1,
                 "VK_KHR_maintenance5": 1,
                 "VK_KHR_maintenance7": 1,
                 "VK_KHR_present_id": 1,

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -981,8 +981,8 @@ namespace dxvk {
     if (m_deviceExtensions.supports(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME))
       m_deviceFeatures.khrExternalSemaphoreWin32 = VK_TRUE;
 
-    if (m_deviceExtensions.supports(VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME))
-      m_deviceFeatures.khrLoadStoreOpNone = VK_TRUE;
+    if (m_deviceExtensions.supports(VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME))
+      m_deviceFeatures.extLoadStoreOpNone = VK_TRUE;
 
     if (m_deviceExtensions.supports(VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
       m_deviceFeatures.khrMaintenance5.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR;
@@ -1077,7 +1077,7 @@ namespace dxvk {
       &devExtensions.extVertexAttributeDivisor,
       &devExtensions.khrExternalMemoryWin32,
       &devExtensions.khrExternalSemaphoreWin32,
-      &devExtensions.khrLoadStoreOpNone,
+      &devExtensions.extLoadStoreOpNone,
       &devExtensions.khrMaintenance5,
       &devExtensions.khrMaintenance7,
       &devExtensions.khrPipelineLibrary,
@@ -1223,8 +1223,8 @@ namespace dxvk {
     if (devExtensions.khrExternalSemaphoreWin32)
       enabledFeatures.khrExternalSemaphoreWin32 = VK_TRUE;
 
-    if (devExtensions.khrLoadStoreOpNone)
-      enabledFeatures.khrLoadStoreOpNone = VK_TRUE;
+    if (devExtensions.extLoadStoreOpNone)
+      enabledFeatures.extLoadStoreOpNone = VK_TRUE;
 
     if (devExtensions.khrMaintenance5) {
       enabledFeatures.khrMaintenance5.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR;
@@ -1407,8 +1407,8 @@ namespace dxvk {
       "\n  extension supported                    : " << (features.khrExternalMemoryWin32 ? "1" : "0") <<
       "\n" << VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME <<
       "\n  extension supported                    : " << (features.khrExternalSemaphoreWin32 ? "1" : "0") <<
-      "\n" << VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME <<
-      "\n  extension supported                    : " << (features.khrLoadStoreOpNone ? "1" : "0") <<
+      "\n" << VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME <<
+      "\n  extension supported                    : " << (features.extLoadStoreOpNone ? "1" : "0") <<
       "\n" << VK_KHR_MAINTENANCE_5_EXTENSION_NAME <<
       "\n  maintenance5                           : " << (features.khrMaintenance5.maintenance5 ? "1" : "0") <<
       "\n" << VK_KHR_MAINTENANCE_7_EXTENSION_NAME <<

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2688,7 +2688,7 @@ namespace dxvk {
     if (access == DxvkAccess::None) {
       // If the attachment is not accessed at all, we can set both the
       // load and store op to NONE if supported by the implementation.
-      bool hasLoadOpNone = m_device->features().khrLoadStoreOpNone;
+      bool hasLoadOpNone = m_device->features().extLoadStoreOpNone;
 
       attachment.loadOp = hasLoadOpNone
         ? VK_ATTACHMENT_LOAD_OP_NONE

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -72,7 +72,7 @@ namespace dxvk {
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT         extVertexAttributeDivisor;
     VkBool32                                                  khrExternalMemoryWin32;
     VkBool32                                                  khrExternalSemaphoreWin32;
-    VkBool32                                                  khrLoadStoreOpNone;
+    VkBool32                                                  extLoadStoreOpNone;
     VkPhysicalDeviceMaintenance5FeaturesKHR                   khrMaintenance5;
     VkPhysicalDeviceMaintenance7FeaturesKHR                   khrMaintenance7;
     VkPhysicalDevicePresentIdFeaturesKHR                      khrPresentId;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -321,7 +321,7 @@ namespace dxvk {
     DxvkExt extVertexAttributeDivisor         = { VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,           DxvkExtMode::Optional };
     DxvkExt khrExternalMemoryWin32            = { VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,              DxvkExtMode::Optional };
     DxvkExt khrExternalSemaphoreWin32         = { VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,           DxvkExtMode::Optional };
-    DxvkExt khrLoadStoreOpNone                = { VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME,                 DxvkExtMode::Optional };
+    DxvkExt extLoadStoreOpNone                = { VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME,                 DxvkExtMode::Optional };
     DxvkExt khrMaintenance5                   = { VK_KHR_MAINTENANCE_5_EXTENSION_NAME,                      DxvkExtMode::Optional };
     DxvkExt khrMaintenance7                   = { VK_KHR_MAINTENANCE_7_EXTENSION_NAME,                      DxvkExtMode::Optional };
     DxvkExt khrPipelineLibrary                = { VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME,                   DxvkExtMode::Optional };


### PR DESCRIPTION
Use "VK_EXT_load_store_op_none" Vulkan extension instead of "VK_KHR_load_store_op_none". 
They are identical, but "VK_EXT_load_store_op_none" available on a broader range of GPU drivers. 
This is especially important for mobile devices with Qualcomm Adreno GPUs, where it is not possible to change or update drivers.

Do not run Workflows on every push. Do not want to waste resources.