### PR TITLE
[release] DXVK-GPLAsync-LowLatency 2.6.1-4 (DXVK-GPLALL 2.6.1-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A Vulkan-based translation layer for Direct3D 8/9/10/11 which allows running 3D applications on: 
 
 1. Windows 10/11, if GPU has Vulkan driver that is Vulkan 1.3 compliant. Requires SSE2 CPU.
-2. Linux using Wine, if GPU has Vulkan driver that is Vulkan 1.3 compliant. Requires SSE3 CPU.
-3. MacOS using Wine/CrossOver, if GPU has Vulkan driver that is Vulkan 1.3 compliant. Requires SSE3 CPU.
+2. Linux using Wine, if GPU has Vulkan driver that is Vulkan 1.3 compliant. Requires SSE2 CPU.
+3. MacOS using Wine/CrossOver, if GPU has Vulkan driver that is Vulkan 1.3 compliant. Requires SSE2 CPU.
 
 ## Major changes compared to [upstream DXVK](https://github.com/doitsujin/dxvk)
 
@@ -23,7 +23,7 @@ Detailed Changelog provided in [Wiki](https://github.com/Digger1955/dxvk-gplasyn
 2. Copy appropriate [DLL dependencies](https://github.com/Digger1955/dxvk-gplasync-lowlatency/blob/test/README.md#dll-dependencies) to the location of application's main executable folder.
 3. Run application.
 
-**Important**: It is STRONGLY RECOMMENDED to create dxvk.conf at application's main executable folder (per-application configuration file - first priority) or at %APPDATA%/dxvk.conf (one global configuration file - second priority) with your desired DXVK settings.
+**Important**: It is STRONGLY RECOMMENDED to create `dxvk.conf` at application's main executable folder (per-application configuration file - first priority) or at `%APPDATA%/dxvk.conf` (one global configuration file - second priority) with your desired DXVK settings.
 
 ## How to use (Linux/MacOS)
 In order to install a DXVK package obtained from the [release](https://github.com/Digger1955/dxvk-gplasync-lowlatency/releases) page into a given wine prefix, copy or symlink the DLLs into the following directories as follows, then open `winecfg` and manually add `native` DLL overrides for `d3d8`, `d3d9`, `d3d10core`, `d3d11` and `dxgi` under the Libraries tab.
@@ -49,7 +49,7 @@ In order to remove DXVK from a prefix, remove the DLLs and DLL overrides, and ru
 
 Tools such as Steam Play, Lutris, Bottles, Heroic Launcher, etc will automatically handle setup of dxvk on their own when enabled.
 
-**Important**: It is STRONGLY RECOMMENDED to create dxvk.conf at application's main executable folder (per-application configuration file - first priority) or at /home/$USER/.config/dxvk.conf (one global configuration file - second priority) with your desired DXVK settings.
+**Important**: It is STRONGLY RECOMMENDED to create `dxvk.conf` at application's main executable folder (per-application configuration file - first priority) or at `/home/$USER/.config/dxvk.conf` (one global configuration file - second priority) with your desired DXVK settings.
 
 ## DLL dependencies 
 Listed below are the DLL requirements for using DXVK with any single API.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,22 @@ A Vulkan-based translation layer for Direct3D 8/9/10/11 which allows running 3D 
 2. Linux using Wine, if GPU has Vulkan driver that is Vulkan 1.3 compliant. Requires SSE2 CPU.
 3. MacOS using Wine/CrossOver, if GPU has Vulkan driver that is Vulkan 1.3 compliant. Requires SSE2 CPU.
 
+For GPUs that do not have Vulkan 1.3 compliant driver, it is recommended to use [DXVK-Sarek](https://github.com/pythonlover02/DXVK-Sarek). It supports Windows 7/8/10/11, Linux/Mac, requires SSE2 CPU, GPU with Vulkan driver that is Vulkan 1.1 compliant. It has implemented Direct3D 8/9/10/11 and a build with Asynchronous pipeline compilation (Async).
+
 ## Major changes compared to [upstream DXVK](https://github.com/doitsujin/dxvk)
 
 1. Implemented Low Latency frame pacing mode that aims to greatly reduce latency with minimal impact in fps. Author - [netborg-afps](https://github.com/netborg-afps/dxvk/releases)
 2. Implemented Asynchronous pipeline compilation (Async) that aims to greatly reduce shader compilation stutter by not blocking the main thread when compiling async pipelines. Authors - [jomihaka](https://github.com/jomihaka/dxvk-poe-hack) and [Sporif](https://github.com/Sporif/dxvk-async)
 3. Implemented the ability to use both (together or separately) Graphics Pipeline Library (GPL) and Asynchronous pipeline compilation (Async) on DXVK 2.1 and later. Author - [Ph42oN](https://gitlab.com/Ph42oN/dxvk-gplasync/)
 4. Implemented all of aforementioned in one DXVK package. Author - [Digger1955](https://github.com/Digger1955/dxvk-gplasync-lowlatency/releases)
-5. Providing Windows (MSVC) builds of DXVK-GPLALL. Author - [Digger1955](https://github.com/Digger1955/dxvk-gplasync-lowlatency/releases)
-6. Providing AVX2 (x86-64-v3) optimized builds of DXVK-GPLALL. Author - [Digger1955](https://github.com/Digger1955/dxvk-gplasync-lowlatency/releases)
+5. Provided various GCC (for any OS) builds of DXVK-GPLALL:
+   a) optimized for `SSE2 (-march=x86-64, -mtune=x86-64)` and newer CPUs;
+   b) optimized for `AVX2 (-march=x86-64-v3, -mtune=x86-64-v3)` and newer CPUs.
+Author - [Digger1955](https://github.com/Digger1955/dxvk-gplasync-lowlatency/releases)
+6. Provided various MSVC (only for Windows, requires [MSVCRT](https://www.techpowerup.com/download/visual-c-redistributable-runtime-package-all-in-one/)) builds of DXVK-GPLALL:
+   a) optimized for `SSE2 (/arch:SSE2)` and newer CPUs;
+   b) optimized for `AVX2 (/arch:AVX2)` and newer CPUs with Link-Time Optimization (`LTO`, a.k.a `/LTCG`) and `/O2` optimization level.
+Author - [Digger1955](https://github.com/Digger1955/dxvk-gplasync-lowlatency/releases)
 
 Detailed Changelog provided in [Wiki](https://github.com/Digger1955/dxvk-gplasync-lowlatency/wiki/Detailed-Changelog).
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ In games that load their shaders during loading screens or in the menu, this can
 
 **Note:** Games which only load their D3D shaders at draw time (e.g. most Unreal Engine games) will still exhibit some stutter, although it should still be less severe than without this feature.
 
+**IMPORTANT**: Disabled by default since 2.6.1-4. Reasons have been specified in [Wiki](https://github.com/Digger1955/dxvk-gplasync-lowlatency/wiki/dxvk.conf-Options-Guide#dxvkenablegraphicspipelinelibrary)
+
 ## State cache
 DXVK caches pipeline state by default, so that shaders can be recompiled ahead of time on subsequent runs of an application, even if the driver's own shader cache got invalidated in the meantime. This cache is enabled by default, and generally reduces stuttering.
 

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -541,15 +541,17 @@
 # Controls graphics pipeline library behaviour
 #
 # Can be used to change VK_EXT_graphics_pipeline_library usage for
-# debugging purpose. Doing so will likely result in increased stutter
-# or degraded performance.
+# debugging purpose. This feature is replaced by Async, 
+# which does not require any specific driver/extension support
+# and provides better performance than using DXVK with GPL 
+# or using DXVK only with state cache.
 #
 # Supported values:
 # - Auto: Enable if supported, and compile optimized pipelines in the background
 # - True: Enable if supported, but do not compile optimized pipelines
 # - False: Always disable the feature
 
-# dxvk.enableGraphicsPipelineLibrary = Auto
+# dxvk.enableGraphicsPipelineLibrary = False
 
 
 # Controls pipeline lifetime tracking

--- a/meson.build
+++ b/meson.build
@@ -10,9 +10,8 @@ cc = meson.get_compiler('c')
 dxvk_is_msvc = cpp.get_argument_syntax() == 'msvc'
 
 compiler_args = [
-  '-msse',
-  '-msse2',
-  '-msse3',
+  '-march=x86-64',
+  '-mtune=x86-64',
   '-mfpmath=sse',
   '-Wimplicit-fallthrough',
   # gcc
@@ -29,7 +28,7 @@ compiler_args = [
 ]
 
 link_args = [
-  '-s',
+  '-Wl,--s',
 ]
 
 if get_option('build_id')
@@ -94,11 +93,11 @@ if platform == 'windows'
       ]
     endif
   else
-    # setup file alignment + enable PDB output for MSVC builds
-    # PDBs are useful for Windows consumers of DXVK 
+    # Windows (MSVC) Compiler Options
     compiler_args += [
       '/arch:SSE2'
     ]
+    # MSVC Linker Options
     link_args += [
       '/FILEALIGN:4096',
       '/DEBUG:NONE'

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ cc = meson.get_compiler('c')
 dxvk_is_msvc = cpp.get_argument_syntax() == 'msvc'
 
 compiler_args = [
+  '-pipe',
   '-march=x86-64',
   '-mtune=x86-64',
   '-mfpmath=sse',

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -17,7 +17,7 @@ namespace dxvk {
     enableStateCache      = config.getOption<bool>    ("dxvk.enableStateCache",       true);
     enableMemoryDefrag    = config.getOption<Tristate>("dxvk.enableMemoryDefrag",     Tristate::Auto);
     numCompilerThreads    = config.getOption<int32_t> ("dxvk.numCompilerThreads",     0);
-    enableGraphicsPipelineLibrary = config.getOption<Tristate>("dxvk.enableGraphicsPipelineLibrary", Tristate::Auto);
+    enableGraphicsPipelineLibrary = config.getOption<Tristate>("dxvk.enableGraphicsPipelineLibrary", Tristate::False);
     trackPipelineLifetime = config.getOption<Tristate>("dxvk.trackPipelineLifetime",  Tristate::Auto);
     useRawSsbo            = config.getOption<Tristate>("dxvk.useRawSsbo",             Tristate::Auto);
     hud                   = config.getOption<std::string>("dxvk.hud", "");
@@ -36,4 +36,4 @@ namespace dxvk {
     tilerMode             = config.getOption<Tristate>("dxvk.tilerMode",              Tristate::Auto);
   }
 
-}
+} 

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -23,7 +23,7 @@ namespace dxvk {
     int32_t numCompilerThreads = 0;
 
     /// Enable graphics pipeline library
-    Tristate enableGraphicsPipelineLibrary = Tristate::Auto;
+    Tristate enableGraphicsPipelineLibrary = Tristate::False;
 
     /// Enables pipeline lifetime tracking
     Tristate trackPipelineLifetime = Tristate::Auto;


### PR DESCRIPTION
DXVK-GPLAsync-LowLatency 2.6.1-4 (DXVK-GPLALL 2.6.1-4)

Detailed Changelog provided in [Wiki](https://github.com/Digger1955/dxvk-gplasync-lowlatency/wiki/Detailed-Changelog#dxvk-gplasync-lowlatency-261-4-dxvk-gplall-261-4).