### PR TITLE
[release] DXVK-GPLAsync-LowLatency 2.6.1-6 (DXVK-GPLALL 2.6.1-6)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,10 +10,14 @@ cc = meson.get_compiler('c')
 dxvk_is_msvc = cpp.get_argument_syntax() == 'msvc'
 
 compiler_args = [
+  '-O3',
   '-pipe',
-  '-march=x86-64-v3',
-  '-mtune=x86-64-v3',
+  '-march=x86-64-v2',
+  '-mtune=generic',
   '-mfpmath=sse',
+  '-fno-semantic-interposition',
+  '-flto',
+  '-fuse-linker-plugin',
   '-Wimplicit-fallthrough',
   # gcc
   '-Wno-missing-field-initializers',

--- a/meson.build
+++ b/meson.build
@@ -92,8 +92,11 @@ if platform == 'windows'
         '-Wl,--enable-stdcall-fixup',
         '-Wl,--kill-at',
       ]
+      # Disable LTO on 32-bit due to GCC bug,
+      # which prevents use of SSE
       # Fix stack alignment issues with mingw on 32-bit
       compiler_args += [
+        '-fno-lto',
         '-mpreferred-stack-boundary=2'
       ]
     endif

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@ compiler_args = [
   '-msse2',
   '-mfpmath=sse',
   '-fno-semantic-interposition',
-  '-flto',
+  '-flto=auto',
   '-fuse-linker-plugin',
   '-Wimplicit-fallthrough',
   # gcc

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,8 @@ compiler_args = [
   '-pipe',
   '-march=x86-64-v2',
   '-mtune=generic',
+  '-msse',
+  '-msse2',
   '-mfpmath=sse',
   '-fno-semantic-interposition',
   '-flto',
@@ -92,11 +94,8 @@ if platform == 'windows'
         '-Wl,--enable-stdcall-fixup',
         '-Wl,--kill-at',
       ]
-      # Disable LTO on 32-bit due to GCC bug,
-      # which prevents use of SSE
       # Fix stack alignment issues with mingw on 32-bit
       compiler_args += [
-        '-fno-lto',
         '-mpreferred-stack-boundary=2'
       ]
     endif


### PR DESCRIPTION
DXVK-GPLAsync-LowLatency 2.6.1-6 (DXVK-GPLALL 2.6.1-6)

Detailed Changelog provided in [Wiki](https://github.com/Digger1955/dxvk-gplasync-lowlatency/wiki/Detailed-Changelog#dxvk-gplasync-lowlatency-261-6-dxvk-gplall-261-6).