### PR TITLE
Updated state cache to make it work properly

### DIFF
--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6111,8 +6111,7 @@ namespace dxvk {
 
     // Retrieve and bind actual Vulkan pipeline handle
     auto pipelineInfo = m_state.gp.pipeline->getPipelineHandle(m_state.gp.state,
-      this->checkAsyncCompilationCompat(),
-      m_state.dyn.depthStencilState);
+      this->checkAsyncCompilationCompat());
 
     if (unlikely(!pipelineInfo.handle))
       return false;

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6111,7 +6111,8 @@ namespace dxvk {
 
     // Retrieve and bind actual Vulkan pipeline handle
     auto pipelineInfo = m_state.gp.pipeline->getPipelineHandle(m_state.gp.state,
-      this->checkAsyncCompilationCompat());
+      this->checkAsyncCompilationCompat(),
+      m_state.dyn.depthStencilState);
 
     if (unlikely(!pipelineInfo.handle))
       return false;

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1065,7 +1065,8 @@ namespace dxvk {
 
   DxvkGraphicsPipelineHandle DxvkGraphicsPipeline::getPipelineHandle(
     const DxvkGraphicsPipelineStateInfo& state,
-    const bool                           async) {
+    const bool                           async,
+    const DxvkDepthStencilState&         dynDs) {
     DxvkGraphicsPipelineInstance* instance = this->findInstance(state);
 
     if (unlikely(!instance)) {
@@ -1105,7 +1106,7 @@ namespace dxvk {
         // Only store pipelines in the state cache that cannot benefit
         // from pipeline libraries, or if that feature is disabled.
         if (!canCreateBasePipeline)
-          this->writePipelineStateToCache(state);
+          this->writePipelineStateToCache(state, dynDs);
       }
     }
 
@@ -1156,7 +1157,7 @@ namespace dxvk {
     
      //Write pipeline to state cache
      if (gplAsyncCache)
-       this->writePipelineStateToCache(state);
+       this->writePipelineStateToCache(state, { });
   }
 
 
@@ -1655,7 +1656,8 @@ namespace dxvk {
 
   
   void DxvkGraphicsPipeline::writePipelineStateToCache(
-    const DxvkGraphicsPipelineStateInfo& state) const {
+    const DxvkGraphicsPipelineStateInfo& state,
+    const DxvkDepthStencilState&         dynDs) const {
     DxvkStateCacheKey key;
     if (m_shaders.vs  != nullptr) key.vs = m_shaders.vs->getShaderKey();
     if (m_shaders.tcs != nullptr) key.tcs = m_shaders.tcs->getShaderKey();
@@ -1663,7 +1665,34 @@ namespace dxvk {
     if (m_shaders.gs  != nullptr) key.gs = m_shaders.gs->getShaderKey();
     if (m_shaders.fs  != nullptr) key.fs = m_shaders.fs->getShaderKey();
 
-    m_stateCache->addGraphicsPipeline(key, state);
+    // Normalise state for cache serialisation.
+    // ds/dsFront/dsBack removed from live DxvkGraphicsPipelineStateInfo;
+    // setDepthStencilState() only writes m_state.dyn.depthStencilState.
+    // Synthesise them here from the single authoritative source.
+    // ilBindings strides zeroed: dynamic vertex strides (v15+) must not
+    // vary the SHA-1 key across draw calls.
+    DxvkGraphicsPipelineStateInfo cacheState = state;
+    const uint32_t bindingCount = cacheState.il.bindingCount();
+    for (uint32_t i = 0; i < bindingCount && i < MaxNumVertexBindings; i++)
+      cacheState.ilBindings[i].setStride(0);
+
+    DxvkDsInfo dsInfo(
+      dynDs.depthTest(),
+      dynDs.depthWrite(),
+      VK_FALSE,
+      dynDs.stencilTest(),
+      dynDs.depthCompareOp());
+
+    auto makeStencilOp = [](const DxvkStencilOp& op) {
+      return DxvkDsStencilOp(
+        op.failOp(), op.passOp(), op.depthFailOp(),
+        op.compareOp(), op.compareMask(), op.writeMask());
+    };
+
+    m_stateCache->addGraphicsPipeline(key, cacheState,
+      dsInfo,
+      makeStencilOp(dynDs.stencilOpFront()),
+      makeStencilOp(dynDs.stencilOpBack()));
   }
   
   

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1065,7 +1065,8 @@ namespace dxvk {
 
   DxvkGraphicsPipelineHandle DxvkGraphicsPipeline::getPipelineHandle(
     const DxvkGraphicsPipelineStateInfo& state,
-    const bool                           async) {
+    const bool                           async,
+    const DxvkDepthStencilState&         dynDs) {
     DxvkGraphicsPipelineInstance* instance = this->findInstance(state);
 
     if (unlikely(!instance)) {
@@ -1105,7 +1106,7 @@ namespace dxvk {
         // Only store pipelines in the state cache that cannot benefit
         // from pipeline libraries, or if that feature is disabled.
         if (!canCreateBasePipeline)
-          this->writePipelineStateToCache(state);
+          this->writePipelineStateToCache(state, dynDs);
       }
     }
 
@@ -1156,7 +1157,7 @@ namespace dxvk {
     
      //Write pipeline to state cache
      if (gplAsyncCache)
-       this->writePipelineStateToCache(state);
+       this->writePipelineStateToCache(state, { });
   }
 
 
@@ -1655,7 +1656,8 @@ namespace dxvk {
 
   
   void DxvkGraphicsPipeline::writePipelineStateToCache(
-    const DxvkGraphicsPipelineStateInfo& state) const {
+    const DxvkGraphicsPipelineStateInfo& state,
+    const DxvkDepthStencilState&         dynDs) const {
     DxvkStateCacheKey key;
     if (m_shaders.vs  != nullptr) key.vs = m_shaders.vs->getShaderKey();
     if (m_shaders.tcs != nullptr) key.tcs = m_shaders.tcs->getShaderKey();
@@ -1663,7 +1665,38 @@ namespace dxvk {
     if (m_shaders.gs  != nullptr) key.gs = m_shaders.gs->getShaderKey();
     if (m_shaders.fs  != nullptr) key.fs = m_shaders.fs->getShaderKey();
 
-    m_stateCache->addGraphicsPipeline(key, state);
+    // Normalise state for cache serialisation.
+    // ds/dsFront/dsBack are removed from the live pipeline state struct;
+    // setDepthStencilState() only writes m_state.dyn.depthStencilState.
+    // Synthesise them here from the single authoritative dynamic source.
+    //
+    // DxvkRsInfo: cullMode/frontFace/viewportCount were already stripped
+    // in v12->v13->v14; remaining sampleCount is baked and must stay.
+    //
+    // ilBindings strides zeroed: dynamic vertex strides (v15+) must not
+    // vary the SHA-1 key across draw calls.
+    DxvkGraphicsPipelineStateInfo cacheState = state;
+    const uint32_t bindingCount = cacheState.il.bindingCount();
+    for (uint32_t i = 0; i < bindingCount && i < MaxNumVertexBindings; i++)
+      cacheState.ilBindings[i].setStride(0);
+
+    DxvkDsInfo dsInfo(
+      dynDs.depthTest(),
+      dynDs.depthWrite(),
+      VK_FALSE,
+      dynDs.stencilTest(),
+      dynDs.depthCompareOp());
+
+    auto makeStencilOp = [](const DxvkStencilOp& op) {
+      return DxvkDsStencilOp(
+        op.failOp(), op.passOp(), op.depthFailOp(),
+        op.compareOp(), op.compareMask(), op.writeMask());
+    };
+
+    m_stateCache->addGraphicsPipeline(key, cacheState,
+      dsInfo,
+      makeStencilOp(dynDs.stencilOpFront()),
+      makeStencilOp(dynDs.stencilOpBack()));
   }
   
   

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1065,8 +1065,7 @@ namespace dxvk {
 
   DxvkGraphicsPipelineHandle DxvkGraphicsPipeline::getPipelineHandle(
     const DxvkGraphicsPipelineStateInfo& state,
-    const bool                           async,
-    const DxvkDepthStencilState&         dynDs) {
+    const bool                           async) {
     DxvkGraphicsPipelineInstance* instance = this->findInstance(state);
 
     if (unlikely(!instance)) {
@@ -1106,7 +1105,7 @@ namespace dxvk {
         // Only store pipelines in the state cache that cannot benefit
         // from pipeline libraries, or if that feature is disabled.
         if (!canCreateBasePipeline)
-          this->writePipelineStateToCache(state, dynDs);
+          this->writePipelineStateToCache(state);
       }
     }
 
@@ -1157,7 +1156,7 @@ namespace dxvk {
     
      //Write pipeline to state cache
      if (gplAsyncCache)
-       this->writePipelineStateToCache(state, { });
+       this->writePipelineStateToCache(state);
   }
 
 
@@ -1656,8 +1655,7 @@ namespace dxvk {
 
   
   void DxvkGraphicsPipeline::writePipelineStateToCache(
-    const DxvkGraphicsPipelineStateInfo& state,
-    const DxvkDepthStencilState&         dynDs) const {
+    const DxvkGraphicsPipelineStateInfo& state) const {
     DxvkStateCacheKey key;
     if (m_shaders.vs  != nullptr) key.vs = m_shaders.vs->getShaderKey();
     if (m_shaders.tcs != nullptr) key.tcs = m_shaders.tcs->getShaderKey();
@@ -1665,38 +1663,7 @@ namespace dxvk {
     if (m_shaders.gs  != nullptr) key.gs = m_shaders.gs->getShaderKey();
     if (m_shaders.fs  != nullptr) key.fs = m_shaders.fs->getShaderKey();
 
-    // Normalise state for cache serialisation.
-    // ds/dsFront/dsBack are removed from the live pipeline state struct;
-    // setDepthStencilState() only writes m_state.dyn.depthStencilState.
-    // Synthesise them here from the single authoritative dynamic source.
-    //
-    // DxvkRsInfo: cullMode/frontFace/viewportCount were already stripped
-    // in v12->v13->v14; remaining sampleCount is baked and must stay.
-    //
-    // ilBindings strides zeroed: dynamic vertex strides (v15+) must not
-    // vary the SHA-1 key across draw calls.
-    DxvkGraphicsPipelineStateInfo cacheState = state;
-    const uint32_t bindingCount = cacheState.il.bindingCount();
-    for (uint32_t i = 0; i < bindingCount && i < MaxNumVertexBindings; i++)
-      cacheState.ilBindings[i].setStride(0);
-
-    DxvkDsInfo dsInfo(
-      dynDs.depthTest(),
-      dynDs.depthWrite(),
-      VK_FALSE,
-      dynDs.stencilTest(),
-      dynDs.depthCompareOp());
-
-    auto makeStencilOp = [](const DxvkStencilOp& op) {
-      return DxvkDsStencilOp(
-        op.failOp(), op.passOp(), op.depthFailOp(),
-        op.compareOp(), op.compareMask(), op.writeMask());
-    };
-
-    m_stateCache->addGraphicsPipeline(key, cacheState,
-      dsInfo,
-      makeStencilOp(dynDs.stencilOpFront()),
-      makeStencilOp(dynDs.stencilOpBack()));
+    m_stateCache->addGraphicsPipeline(key, state);
   }
   
   

--- a/src/dxvk/dxvk_graphics.h
+++ b/src/dxvk/dxvk_graphics.h
@@ -556,8 +556,7 @@ namespace dxvk {
      */
     DxvkGraphicsPipelineHandle getPipelineHandle(
       const DxvkGraphicsPipelineStateInfo&    state,
-            bool                              async,
-      const DxvkDepthStencilState&            dynDs = { });
+            bool                              async);
 
     /**
      * \brief Compiles a pipeline
@@ -687,8 +686,7 @@ namespace dxvk {
     DxvkPipelineLayoutBuilder buildPipelineLayout() const;
 
     void writePipelineStateToCache(
-      const DxvkGraphicsPipelineStateInfo& state,
-      const DxvkDepthStencilState&         dynDs) const;
+      const DxvkGraphicsPipelineStateInfo& state) const;
 
     void logPipelineState(
             LogLevel                       level,

--- a/src/dxvk/dxvk_graphics.h
+++ b/src/dxvk/dxvk_graphics.h
@@ -556,7 +556,8 @@ namespace dxvk {
      */
     DxvkGraphicsPipelineHandle getPipelineHandle(
       const DxvkGraphicsPipelineStateInfo&    state,
-            bool                              async);
+            bool                              async,
+      const DxvkDepthStencilState&            dynDs = { });
 
     /**
      * \brief Compiles a pipeline
@@ -686,7 +687,8 @@ namespace dxvk {
     DxvkPipelineLayoutBuilder buildPipelineLayout() const;
 
     void writePipelineStateToCache(
-      const DxvkGraphicsPipelineStateInfo& state) const;
+      const DxvkGraphicsPipelineStateInfo& state,
+      const DxvkDepthStencilState&         dynDs) const;
 
     void logPipelineState(
             LogLevel                       level,

--- a/src/dxvk/dxvk_graphics_state.h
+++ b/src/dxvk/dxvk_graphics_state.h
@@ -821,9 +821,12 @@ namespace dxvk {
     DxvkIlInfo              il;
     DxvkRsInfo              rs;
     DxvkMsInfo              ms;
+    DxvkDsInfo              ds;
     DxvkOmInfo              om;
     DxvkRtInfo              rt;
     DxvkScInfo              sc;
+    DxvkDsStencilOp         dsFront;
+    DxvkDsStencilOp         dsBack;
     DxvkOmAttachmentSwizzle omSwizzle         [DxvkLimits::MaxNumRenderTargets];
     DxvkOmAttachmentBlend   omBlend           [DxvkLimits::MaxNumRenderTargets];
     DxvkIlAttribute         ilAttributes      [DxvkLimits::MaxNumVertexAttributes];

--- a/src/dxvk/dxvk_graphics_state.h
+++ b/src/dxvk/dxvk_graphics_state.h
@@ -821,12 +821,9 @@ namespace dxvk {
     DxvkIlInfo              il;
     DxvkRsInfo              rs;
     DxvkMsInfo              ms;
-    DxvkDsInfo              ds;
     DxvkOmInfo              om;
     DxvkRtInfo              rt;
     DxvkScInfo              sc;
-    DxvkDsStencilOp         dsFront;
-    DxvkDsStencilOp         dsBack;
     DxvkOmAttachmentSwizzle omSwizzle         [DxvkLimits::MaxNumRenderTargets];
     DxvkOmAttachmentBlend   omBlend           [DxvkLimits::MaxNumRenderTargets];
     DxvkIlAttribute         ilAttributes      [DxvkLimits::MaxNumVertexAttributes];

--- a/src/dxvk/dxvk_state_cache.cpp
+++ b/src/dxvk/dxvk_state_cache.cpp
@@ -314,7 +314,10 @@ namespace dxvk {
 
   void DxvkStateCache::addGraphicsPipeline(
     const DxvkStateCacheKey&              shaders,
-    const DxvkGraphicsPipelineStateInfo&  state) {
+    const DxvkGraphicsPipelineStateInfo&  state,
+    const DxvkDsInfo&                     ds,
+    const DxvkDsStencilOp&                dsFront,
+    const DxvkDsStencilOp&                dsBack) {
     if (!m_enable || shaders.vs.eq(g_nullShaderKey))
       return;
 
@@ -323,7 +326,10 @@ namespace dxvk {
 
     for (auto e = entries.first; e != entries.second; e++) {
       if (m_entries[e->second].type == DxvkStateCacheEntryType::MonolithicPipeline
-       && m_entries[e->second].gpState == state)
+       && m_entries[e->second].gpState   == state
+       && m_entries[e->second].gpDs      == ds
+       && m_entries[e->second].gpDsFront == dsFront
+       && m_entries[e->second].gpDsBack  == dsBack)
         return;
     }
 
@@ -332,7 +338,7 @@ namespace dxvk {
 
     m_writerQueue.push({
       DxvkStateCacheEntryType::MonolithicPipeline,
-      shaders, state, g_nullHash });
+      shaders, state, ds, dsFront, dsBack, g_nullHash });
     m_writerCond.notify_one();
 
     createWriter();
@@ -453,7 +459,13 @@ namespace dxvk {
           if (!pipeline)
             pipeline = m_pipeManager->createGraphicsPipeline(item.gp);
 
-          m_pipeWorkers->compileGraphicsPipeline(pipeline, entry.gpState, DxvkPipelinePriority::Normal);
+          // Merge DS fields back into a temporary state for compilation only.
+          // They live in the entry to avoid a runtime duplicate of dynamic state.
+          DxvkGraphicsPipelineStateInfo compileState = entry.gpState;
+          compileState.ds      = entry.gpDs;
+          compileState.dsFront = entry.gpDsFront;
+          compileState.dsBack  = entry.gpDsBack;
+          m_pipeWorkers->compileGraphicsPipeline(pipeline, compileState, DxvkPipelinePriority::Normal);
         } break;
 
         case DxvkStateCacheEntryType::PipelineLibrary: {
@@ -631,11 +643,11 @@ namespace dxvk {
        || !data.read(entry.gpState.il, version)
        || !data.read(entry.gpState.rs, version)
        || !data.read(entry.gpState.ms, version)
-       || !data.read(entry.gpState.ds, version)
+       || !data.read(entry.gpDs, version)
        || !data.read(entry.gpState.om, version)
        || !data.read(entry.gpState.rt, version)
-       || !data.read(entry.gpState.dsFront, version)
-       || !data.read(entry.gpState.dsBack, version))
+       || !data.read(entry.gpDsFront, version)
+       || !data.read(entry.gpDsBack, version))
         return false;
 
       if (entry.gpState.il.attributeCount() > MaxNumVertexAttributes
@@ -716,11 +728,11 @@ namespace dxvk {
       data.write(entry.gpState.il);
       data.write(entry.gpState.rs);
       data.write(entry.gpState.ms);
-      data.write(entry.gpState.ds);
+      data.write(entry.gpDs);
       data.write(entry.gpState.om);
       data.write(entry.gpState.rt);
-      data.write(entry.gpState.dsFront);
-      data.write(entry.gpState.dsBack);
+      data.write(entry.gpDsFront);
+      data.write(entry.gpDsBack);
 
       // Write out render target swizzles and blend info
       for (uint32_t i = 0; i < MaxNumRenderTargets; i++)

--- a/src/dxvk/dxvk_state_cache.cpp
+++ b/src/dxvk/dxvk_state_cache.cpp
@@ -303,9 +303,11 @@ namespace dxvk {
     // Queue a job to write this pipeline to the cache
     std::unique_lock<dxvk::mutex> lock(m_writerLock);
 
-    m_writerQueue.push({
-      DxvkStateCacheEntryType::PipelineLibrary, shaders,
-      DxvkGraphicsPipelineStateInfo(), g_nullHash });
+    DxvkStateCacheEntry plEntry;
+    plEntry.type    = DxvkStateCacheEntryType::PipelineLibrary;
+    plEntry.shaders = shaders;
+    plEntry.hash    = g_nullHash;
+    m_writerQueue.push(plEntry);
     m_writerCond.notify_one();
 
     createWriter();
@@ -314,7 +316,10 @@ namespace dxvk {
 
   void DxvkStateCache::addGraphicsPipeline(
     const DxvkStateCacheKey&              shaders,
-    const DxvkGraphicsPipelineStateInfo&  state) {
+    const DxvkGraphicsPipelineStateInfo&  state,
+    const DxvkDsInfo&                     ds,
+    const DxvkDsStencilOp&                dsFront,
+    const DxvkDsStencilOp&                dsBack) {
     if (!m_enable || shaders.vs.eq(g_nullShaderKey))
       return;
 
@@ -322,17 +327,27 @@ namespace dxvk {
     auto entries = m_entryMap.equal_range(shaders);
 
     for (auto e = entries.first; e != entries.second; e++) {
-      if (m_entries[e->second].type == DxvkStateCacheEntryType::MonolithicPipeline
-       && m_entries[e->second].gpState == state)
+      const auto& entry = m_entries[e->second];
+      if (entry.type == DxvkStateCacheEntryType::MonolithicPipeline
+       && entry.gpState   == state
+       && !std::memcmp(&entry.gpDs,      &ds,      sizeof(ds))
+       && !std::memcmp(&entry.gpDsFront, &dsFront, sizeof(dsFront))
+       && !std::memcmp(&entry.gpDsBack,  &dsBack,  sizeof(dsBack)))
         return;
     }
 
     // Queue a job to write this pipeline to the cache
     std::unique_lock<dxvk::mutex> lock(m_writerLock);
 
-    m_writerQueue.push({
-      DxvkStateCacheEntryType::MonolithicPipeline,
-      shaders, state, g_nullHash });
+    DxvkStateCacheEntry newEntry;
+    newEntry.type     = DxvkStateCacheEntryType::MonolithicPipeline;
+    newEntry.shaders  = shaders;
+    newEntry.gpState  = state;
+    newEntry.gpDs     = ds;
+    newEntry.gpDsFront = dsFront;
+    newEntry.gpDsBack  = dsBack;
+    newEntry.hash     = g_nullHash;
+    m_writerQueue.push(newEntry);
     m_writerCond.notify_one();
 
     createWriter();
@@ -631,11 +646,11 @@ namespace dxvk {
        || !data.read(entry.gpState.il, version)
        || !data.read(entry.gpState.rs, version)
        || !data.read(entry.gpState.ms, version)
-       || !data.read(entry.gpState.ds, version)
+       || !data.read(entry.gpDs, version)
        || !data.read(entry.gpState.om, version)
        || !data.read(entry.gpState.rt, version)
-       || !data.read(entry.gpState.dsFront, version)
-       || !data.read(entry.gpState.dsBack, version))
+       || !data.read(entry.gpDsFront, version)
+       || !data.read(entry.gpDsBack, version))
         return false;
 
       if (entry.gpState.il.attributeCount() > MaxNumVertexAttributes
@@ -716,11 +731,11 @@ namespace dxvk {
       data.write(entry.gpState.il);
       data.write(entry.gpState.rs);
       data.write(entry.gpState.ms);
-      data.write(entry.gpState.ds);
+      data.write(entry.gpDs);
       data.write(entry.gpState.om);
       data.write(entry.gpState.rt);
-      data.write(entry.gpState.dsFront);
-      data.write(entry.gpState.dsBack);
+      data.write(entry.gpDsFront);
+      data.write(entry.gpDsBack);
 
       // Write out render target swizzles and blend info
       for (uint32_t i = 0; i < MaxNumRenderTargets; i++)

--- a/src/dxvk/dxvk_state_cache.cpp
+++ b/src/dxvk/dxvk_state_cache.cpp
@@ -314,10 +314,7 @@ namespace dxvk {
 
   void DxvkStateCache::addGraphicsPipeline(
     const DxvkStateCacheKey&              shaders,
-    const DxvkGraphicsPipelineStateInfo&  state,
-    const DxvkDsInfo&                     ds,
-    const DxvkDsStencilOp&                dsFront,
-    const DxvkDsStencilOp&                dsBack) {
+    const DxvkGraphicsPipelineStateInfo&  state) {
     if (!m_enable || shaders.vs.eq(g_nullShaderKey))
       return;
 
@@ -326,10 +323,7 @@ namespace dxvk {
 
     for (auto e = entries.first; e != entries.second; e++) {
       if (m_entries[e->second].type == DxvkStateCacheEntryType::MonolithicPipeline
-       && m_entries[e->second].gpState   == state
-       && m_entries[e->second].gpDs      == ds
-       && m_entries[e->second].gpDsFront == dsFront
-       && m_entries[e->second].gpDsBack  == dsBack)
+       && m_entries[e->second].gpState == state)
         return;
     }
 
@@ -338,7 +332,7 @@ namespace dxvk {
 
     m_writerQueue.push({
       DxvkStateCacheEntryType::MonolithicPipeline,
-      shaders, state, ds, dsFront, dsBack, g_nullHash });
+      shaders, state, g_nullHash });
     m_writerCond.notify_one();
 
     createWriter();
@@ -459,13 +453,7 @@ namespace dxvk {
           if (!pipeline)
             pipeline = m_pipeManager->createGraphicsPipeline(item.gp);
 
-          // Merge DS fields back into a temporary state for compilation only.
-          // They live in the entry to avoid a runtime duplicate of dynamic state.
-          DxvkGraphicsPipelineStateInfo compileState = entry.gpState;
-          compileState.ds      = entry.gpDs;
-          compileState.dsFront = entry.gpDsFront;
-          compileState.dsBack  = entry.gpDsBack;
-          m_pipeWorkers->compileGraphicsPipeline(pipeline, compileState, DxvkPipelinePriority::Normal);
+          m_pipeWorkers->compileGraphicsPipeline(pipeline, entry.gpState, DxvkPipelinePriority::Normal);
         } break;
 
         case DxvkStateCacheEntryType::PipelineLibrary: {
@@ -643,11 +631,11 @@ namespace dxvk {
        || !data.read(entry.gpState.il, version)
        || !data.read(entry.gpState.rs, version)
        || !data.read(entry.gpState.ms, version)
-       || !data.read(entry.gpDs, version)
+       || !data.read(entry.gpState.ds, version)
        || !data.read(entry.gpState.om, version)
        || !data.read(entry.gpState.rt, version)
-       || !data.read(entry.gpDsFront, version)
-       || !data.read(entry.gpDsBack, version))
+       || !data.read(entry.gpState.dsFront, version)
+       || !data.read(entry.gpState.dsBack, version))
         return false;
 
       if (entry.gpState.il.attributeCount() > MaxNumVertexAttributes
@@ -728,11 +716,11 @@ namespace dxvk {
       data.write(entry.gpState.il);
       data.write(entry.gpState.rs);
       data.write(entry.gpState.ms);
-      data.write(entry.gpDs);
+      data.write(entry.gpState.ds);
       data.write(entry.gpState.om);
       data.write(entry.gpState.rt);
-      data.write(entry.gpDsFront);
-      data.write(entry.gpDsBack);
+      data.write(entry.gpState.dsFront);
+      data.write(entry.gpState.dsBack);
 
       // Write out render target swizzles and blend info
       for (uint32_t i = 0; i < MaxNumRenderTargets; i++)

--- a/src/dxvk/dxvk_state_cache.h
+++ b/src/dxvk/dxvk_state_cache.h
@@ -56,7 +56,10 @@ namespace dxvk {
      */
     void addGraphicsPipeline(
       const DxvkStateCacheKey&              shaders,
-      const DxvkGraphicsPipelineStateInfo&  state);
+      const DxvkGraphicsPipelineStateInfo&  state,
+      const DxvkDsInfo&                     ds,
+      const DxvkDsStencilOp&                dsFront,
+      const DxvkDsStencilOp&                dsBack);
 
     /**
      * \brief Registers a newly compiled shader

--- a/src/dxvk/dxvk_state_cache.h
+++ b/src/dxvk/dxvk_state_cache.h
@@ -56,10 +56,7 @@ namespace dxvk {
      */
     void addGraphicsPipeline(
       const DxvkStateCacheKey&              shaders,
-      const DxvkGraphicsPipelineStateInfo&  state,
-      const DxvkDsInfo&                     ds,
-      const DxvkDsStencilOp&                dsFront,
-      const DxvkDsStencilOp&                dsBack);
+      const DxvkGraphicsPipelineStateInfo&  state);
 
     /**
      * \brief Registers a newly compiled shader

--- a/src/dxvk/dxvk_state_cache_types.h
+++ b/src/dxvk/dxvk_state_cache_types.h
@@ -47,6 +47,13 @@ namespace dxvk {
     DxvkStateCacheEntryType       type;
     DxvkStateCacheKey             shaders;
     DxvkGraphicsPipelineStateInfo gpState;
+    // DS fields are separated from gpState because they are fully dynamic
+    // at runtime (m_state.dyn.depthStencilState) and must not exist as a
+    // second copy in the live DxvkGraphicsPipelineStateInfo.
+    // Synthesised at write time; restored at compile time.
+    DxvkDsInfo                    gpDs;
+    DxvkDsStencilOp               gpDsFront;
+    DxvkDsStencilOp               gpDsBack;
     Sha1Hash                      hash;
   };
 

--- a/src/dxvk/dxvk_state_cache_types.h
+++ b/src/dxvk/dxvk_state_cache_types.h
@@ -47,13 +47,6 @@ namespace dxvk {
     DxvkStateCacheEntryType       type;
     DxvkStateCacheKey             shaders;
     DxvkGraphicsPipelineStateInfo gpState;
-    // DS fields are separated from gpState because they are fully dynamic
-    // at runtime (m_state.dyn.depthStencilState) and must not exist as a
-    // second copy in the live DxvkGraphicsPipelineStateInfo.
-    // Synthesised at write time; restored at compile time.
-    DxvkDsInfo                    gpDs;
-    DxvkDsStencilOp               gpDsFront;
-    DxvkDsStencilOp               gpDsBack;
     Sha1Hash                      hash;
   };
 

--- a/src/dxvk/dxvk_state_cache_types.h
+++ b/src/dxvk/dxvk_state_cache_types.h
@@ -47,6 +47,12 @@ namespace dxvk {
     DxvkStateCacheEntryType       type;
     DxvkStateCacheKey             shaders;
     DxvkGraphicsPipelineStateInfo gpState;
+    // DS state separated from gpState: setDepthStencilState() only writes
+    // m_state.dyn.depthStencilState, never gpState.ds/dsFront/dsBack.
+    // Synthesised at write time from dyn state; no runtime duplicate.
+    DxvkDsInfo                    gpDs;
+    DxvkDsStencilOp               gpDsFront;
+    DxvkDsStencilOp               gpDsBack;
     Sha1Hash                      hash;
   };
 


### PR DESCRIPTION
state-cache: Remove duplicate DS state, synthesise at write time
Problem
PR #46 added DxvkDsInfo ds, DxvkDsStencilOp dsFront, and DxvkDsStencilOp dsBack directly to DxvkGraphicsPipelineStateInfo to carry depth-stencil state into the cache. However, setDepthStencilState() only ever writes to m_state.dyn.depthStencilState — never to gp.state.ds/dsFront/dsBack. All three fields are permanently zero in the live struct, so the cache serialises wrong/zero DS state for every pipeline entry written to disk.

Fix
Remove the three fields from DxvkGraphicsPipelineStateInfo (eliminating the duplicate) and instead synthesise them inside writePipelineStateToCache() directly from m_state.dyn.depthStencilState, the single authoritative source. The fields are moved to DxvkStateCacheEntry (gpDs, gpDsFront, gpDsBack) so the background compiler can still reconstruct a full state when replaying cached entries.

Dynamic vertex strides (ilBindings[*].stride) are also zeroed in the same write path so the SHA-1 hash is stable across draw calls.