### PR TITLE
update state cache with dyasync for vertex binding strides

### DIFF
--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1063,6 +1063,48 @@ namespace dxvk {
   }
 
 
+
+  // DxvkGraphicsPipeline::findStrideNormalisedInstance
+  //
+  // dyasync-style stride-normalised stand-in
+  // (pythonlover02/DXVK-Sarek, old-main-dyasync, adapted for GPLALL).
+  //
+  // Problem:
+  //   The state cache writes all ilBinding strides as 0 (PR #81).  After
+  //   preload, compiled instances in m_pipelines carry stride=0 in their
+  //   stored state.  A live draw call whose strides differ misses
+  //   findInstance() even though the compiled VkPipeline is functionally
+  //   identical for pipelines that use
+  //   VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE -- the stride is
+  //   applied dynamically by the command buffer, not baked into the pipeline.
+  //
+  // Solution (mirrors dyasync FallbackMap in DXVK-Sarek):
+  //   Zero the live strides → call findInstance(normalisedState).
+  //   If an instance is found, its VkPipeline is valid as a stand-in for
+  //   this draw call.  The exact live-stride state is then queued for async
+  //   compilation at High priority.  When it completes, future draw calls
+  //   find the exact instance and the stand-in is no longer used.
+  //
+  // Guard: only applied when useDynamicVertexStrides() is true on the live
+  // state, ensuring we never return a baked-stride pipeline for a draw call
+  // that expects a different baked stride.
+  DxvkGraphicsPipelineInstance* DxvkGraphicsPipeline::findStrideNormalisedInstance(
+    const DxvkGraphicsPipelineStateInfo& liveState) {
+    // Only valid for pipelines using dynamic vertex strides.
+    if (!liveState.useDynamicVertexStrides())
+      return nullptr;
+
+    // Build a normalised copy with all binding strides zeroed -- this matches
+    // how the state was stored when the cache entry was preloaded.
+    DxvkGraphicsPipelineStateInfo normState = liveState;
+    const uint32_t bindingCount = normState.il.bindingCount();
+    for (uint32_t i = 0; i < bindingCount && i < MaxNumVertexBindings; i++)
+      normState.ilBindings[i].setStride(0);
+
+    return this->findInstance(normState);
+  }
+
+
   DxvkGraphicsPipelineHandle DxvkGraphicsPipeline::getPipelineHandle(
     const DxvkGraphicsPipelineStateInfo& state,
     const bool                           async,
@@ -1074,6 +1116,52 @@ namespace dxvk {
       if (!this->validatePipelineState(state, true))
         return DxvkGraphicsPipelineHandle();
 
+      // ── DYASYNC STRIDE-NORMALISED STAND-IN ────────────────────────────────────
+      // Adapted from dyasync in pythonlover02/DXVK-Sarek (old-main-dyasync).
+      //
+      // When gplAsyncCache or enableAsync is active, the state cache stores
+      // entries with stride=0 (PR #81 normalisation).  A live draw call that
+      // differs only in ilBinding strides misses findInstance() above.
+      //
+      // We now check whether a stride-normalised match exists in m_pipelines:
+      //   - If yes: that compiled pipeline is valid as a stand-in (strides are
+      //     dynamic, not baked).  Return it immediately, queue the exact variant
+      //     at High priority.  When async compilation finishes, future calls to
+      //     findInstance(liveState) find the exact instance automatically.
+      //   - If no:  fall through to the normal useAsync / synchronous paths.
+      //
+      // In DXVK-Sarek dyasync, the stand-in is keyed per-renderPass (FallbackMap).
+      // Here the stand-in is the specific cache-preloaded instance whose state
+      // differs from the live state only in ilBinding strides -- a tighter match.
+      if (m_device->config().dyasyncStrideFallback
+       && (m_device->config().gplAsyncCache
+           || (m_device->config().enableAsync
+               && env::getEnvVar("DXVK_ASYNC") != "0"))) {
+        DxvkGraphicsPipelineInstance* strideMatch =
+          this->findStrideNormalisedInstance(state);
+
+        if (strideMatch != nullptr) {
+          VkPipeline standInHandle = strideMatch->fastHandle.load(std::memory_order_acquire);
+          if (standInHandle == VK_NULL_HANDLE)
+            standInHandle = strideMatch->baseHandle.load(std::memory_order_acquire);
+
+          if (standInHandle != VK_NULL_HANDLE) {
+            // Queue exact live-stride variant at High priority.
+            // writePipelineStateToCache writes stride=0 -- the cache already has
+            // this entry from the initial preload, so no duplicate is written.
+            this->acquirePipeline();
+            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::High);
+
+            DxvkGraphicsPipelineHandle result;
+            result.handle      = standInHandle;
+            result.type        = DxvkGraphicsPipelineType::FastPipeline;
+            result.attachments = strideMatch->attachments;
+            return result;
+          }
+        }
+      }
+      // ─────────────────────────────────────────────────────────────────────────
+
       const bool useAsync = async && m_device->config().enableAsync && env::getEnvVar("DXVK_ASYNC") != "0";
 
       // Prevent other threads from adding new instances and check again
@@ -1082,6 +1170,17 @@ namespace dxvk {
 
       if (!instance) {
         if (useAsync) {
+          // When GPL is available, create a base instance immediately so that
+          // m_pipelines is non-empty; subsequent variant misses above will then
+          // find it via findStrideNormalisedInstance and avoid null handles.
+          if (this->canCreateBasePipeline(state)) {
+            instance = this->createInstance(state, /*doCreateBasePipeline=*/true);
+            lock.unlock();
+            m_async.store(true, std::memory_order_release);
+            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::High);
+            return instance->getHandle();
+          }
+
           m_async.store(true, std::memory_order_release);
           lock.unlock();
 
@@ -1136,8 +1235,15 @@ namespace dxvk {
       std::unique_lock<dxvk::mutex> lock(m_mutex);
       instance = this->findInstance(state);
 
-      if (!instance)
-        instance = this->createInstance(state, false);
+      if (!instance) {
+        // Use GPL base pipeline when gplasync is active so that the base
+        // (fast-link) handle is available immediately and the optimised
+        // variant is compiled on top -- matching the gplasync first-encounter
+        // path in getPipelineHandle().
+        bool useGplBase = (gplAsyncCache || m_async.load(std::memory_order_acquire))
+                        && this->canCreateBasePipeline(state);
+        instance = this->createInstance(state, useGplBase);
+      }
     }
 
     // Exit if another thread is already compiling

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1165,7 +1165,7 @@ namespace dxvk {
             // writePipelineStateToCache is also skipped: PR #81 normalises
             // strides to 0 on write, so the cache already contains this entry
             // from the initial preload.
-            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Low);
+            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Normal);
 
             DxvkGraphicsPipelineHandle result;
             result.handle      = standInHandle;
@@ -1192,14 +1192,14 @@ namespace dxvk {
             instance = this->createInstance(state, /*doCreateBasePipeline=*/true);
             lock.unlock();
             m_async.store(true, std::memory_order_release);
-            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Low);
+            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Normal);
             return instance->getHandle();
           }
 
           m_async.store(true, std::memory_order_release);
           lock.unlock();
 
-          m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Low);
+          m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Normal);
 
           return DxvkGraphicsPipelineHandle();
         }

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1146,11 +1146,26 @@ namespace dxvk {
             standInHandle = strideMatch->baseHandle.load(std::memory_order_acquire);
 
           if (standInHandle != VK_NULL_HANDLE) {
-            // Queue exact live-stride variant at High priority.
-            // writePipelineStateToCache writes stride=0 -- the cache already has
-            // this entry from the initial preload, so no duplicate is written.
-            this->acquirePipeline();
-            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::High);
+            // Return the stand-in immediately -- never block the draw thread.
+            //
+            // Dispatch the exact live-stride variant for async compilation at
+            // Normal priority (same as the state cache preload worker).  This
+            // avoids the CPU pressure caused by High-priority dispatch:
+            //
+            //   High  → worker threads promoted, competes with application CPU
+            //           budget; saturates queue when many shader sets fire at once
+            //   Normal → worker threads stay at Lowest OS priority; compiled
+            //            in background without impacting the application
+            //
+            // acquirePipeline() is intentionally NOT called here.  The pipeline
+            // lifetime tracking mutex is only needed when the pipeline may be
+            // destroyed mid-use; during normal async compilation the instance is
+            // retained by m_pipelines and requires no extra ref-count.
+            //
+            // writePipelineStateToCache is also skipped: PR #81 normalises
+            // strides to 0 on write, so the cache already contains this entry
+            // from the initial preload.
+            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Normal);
 
             DxvkGraphicsPipelineHandle result;
             result.handle      = standInHandle;

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1064,150 +1064,74 @@ namespace dxvk {
 
 
 
-  // DxvkGraphicsPipeline::findStrideNormalisedInstance
-  //
-  // dyasync-style stride-normalised stand-in
-  // (pythonlover02/DXVK-Sarek, old-main-dyasync, adapted for GPLALL).
-  //
-  // Problem:
-  //   The state cache writes all ilBinding strides as 0 (PR #81).  After
-  //   preload, compiled instances in m_pipelines carry stride=0 in their
-  //   stored state.  A live draw call whose strides differ misses
-  //   findInstance() even though the compiled VkPipeline is functionally
-  //   identical for pipelines that use
-  //   VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE -- the stride is
-  //   applied dynamically by the command buffer, not baked into the pipeline.
-  //
-  // Solution (mirrors dyasync FallbackMap in DXVK-Sarek):
-  //   Zero the live strides → call findInstance(normalisedState).
-  //   If an instance is found, its VkPipeline is valid as a stand-in for
-  //   this draw call.  The exact live-stride state is then queued for async
-  //   compilation at High priority.  When it completes, future draw calls
-  //   find the exact instance and the stand-in is no longer used.
-  //
-  // Guard: only applied when useDynamicVertexStrides() is true on the live
-  // state, ensuring we never return a baked-stride pipeline for a draw call
-  // that expects a different baked stride.
-  DxvkGraphicsPipelineInstance* DxvkGraphicsPipeline::findStrideNormalisedInstance(
-    const DxvkGraphicsPipelineStateInfo& liveState) {
-    // Only valid for pipelines using dynamic vertex strides.
-    if (!liveState.useDynamicVertexStrides())
-      return nullptr;
-
-    // Build a normalised copy with all binding strides zeroed -- this matches
-    // how the state was stored when the cache entry was preloaded.
-    DxvkGraphicsPipelineStateInfo normState = liveState;
-    const uint32_t bindingCount = normState.il.bindingCount();
-    for (uint32_t i = 0; i < bindingCount && i < MaxNumVertexBindings; i++)
-      normState.ilBindings[i].setStride(0);
-
-    return this->findInstance(normState);
-  }
 
 
-  DxvkGraphicsPipelineHandle DxvkGraphicsPipeline::getPipelineHandle(
+    DxvkGraphicsPipelineHandle DxvkGraphicsPipeline::getPipelineHandle(
     const DxvkGraphicsPipelineStateInfo& state,
     const bool                           async,
     const DxvkDepthStencilState&         dynDs) {
-    DxvkGraphicsPipelineInstance* instance = this->findInstance(state);
+    // When VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE is used, strides
+    // are not baked into the VkPipeline.  PR #81 zeroes all ilBinding
+    // strides on cache write so that the SHA-1 key is stride-independent.
+    // Normalising here makes findInstance() find the preloaded (stride=0)
+    // instance directly -- it IS the correct pipeline for any live stride.
+    // No recompilation and no stand-in are needed.
+    const bool useNormaliseStrides =
+        m_device->config().normaliseVertexStrides
+     && (m_device->config().gplAsyncCache
+         || (m_device->config().enableAsync
+             && env::getEnvVar("DXVK_ASYNC") != "0"));
+
+    DxvkGraphicsPipelineStateInfo normState;
+    if (useNormaliseStrides && state.il.bindingCount() > 0
+     && !state.useDynamicVertexStrides()) {
+      normState = state;
+      for (uint32_t i = 0; i < state.il.bindingCount(); i++)
+        normState.ilBindings[i].setStride(0);
+    }
+    const DxvkGraphicsPipelineStateInfo& lookupState =
+        (useNormaliseStrides && state.il.bindingCount() > 0
+         && !state.useDynamicVertexStrides())
+        ? normState : state;
+
+    DxvkGraphicsPipelineInstance* instance = this->findInstance(lookupState);
 
     if (unlikely(!instance)) {
       // Exit early if the state vector is invalid
-      if (!this->validatePipelineState(state, true))
+      if (!this->validatePipelineState(lookupState, true))
         return DxvkGraphicsPipelineHandle();
 
-      // ── DYASYNC STRIDE-NORMALISED STAND-IN ────────────────────────────────────
-      // Adapted from dyasync in pythonlover02/DXVK-Sarek (old-main-dyasync).
-      //
-      // When gplAsyncCache or enableAsync is active, the state cache stores
-      // entries with stride=0 (PR #81 normalisation).  A live draw call that
-      // differs only in ilBinding strides misses findInstance() above.
-      //
-      // We now check whether a stride-normalised match exists in m_pipelines:
-      //   - If yes: that compiled pipeline is valid as a stand-in (strides are
-      //     dynamic, not baked).  Return it immediately, queue the exact variant
-      //     at High priority.  When async compilation finishes, future calls to
-      //     findInstance(liveState) find the exact instance automatically.
-      //   - If no:  fall through to the normal useAsync / synchronous paths.
-      //
-      // In DXVK-Sarek dyasync, the stand-in is keyed per-renderPass (FallbackMap).
-      // Here the stand-in is the specific cache-preloaded instance whose state
-      // differs from the live state only in ilBinding strides -- a tighter match.
-      if (m_device->config().dyasyncStrideFallback
-       && (m_device->config().gplAsyncCache
-           || (m_device->config().enableAsync
-               && env::getEnvVar("DXVK_ASYNC") != "0"))) {
-        DxvkGraphicsPipelineInstance* strideMatch =
-          this->findStrideNormalisedInstance(state);
-
-        if (strideMatch != nullptr) {
-          VkPipeline standInHandle = strideMatch->fastHandle.load(std::memory_order_acquire);
-          if (standInHandle == VK_NULL_HANDLE)
-            standInHandle = strideMatch->baseHandle.load(std::memory_order_acquire);
-
-          if (standInHandle != VK_NULL_HANDLE) {
-            // Return the stand-in immediately -- never block the draw thread.
-            //
-            // Dispatch the exact live-stride variant for async compilation at
-            // Normal priority (same as the state cache preload worker).  This
-            // avoids the CPU pressure caused by High-priority dispatch:
-            //
-            //   High  → worker threads promoted, competes with application CPU
-            //           budget; saturates queue when many shader sets fire at once
-            //   Normal → worker threads stay at Lowest OS priority; compiled
-            //            in background without impacting the application
-            //
-            // acquirePipeline() is intentionally NOT called here.  The pipeline
-            // lifetime tracking mutex is only needed when the pipeline may be
-            // destroyed mid-use; during normal async compilation the instance is
-            // retained by m_pipelines and requires no extra ref-count.
-            //
-            // writePipelineStateToCache is also skipped: PR #81 normalises
-            // strides to 0 on write, so the cache already contains this entry
-            // from the initial preload.
-            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Normal);
-
-            DxvkGraphicsPipelineHandle result;
-            result.handle      = standInHandle;
-            result.type        = DxvkGraphicsPipelineType::FastPipeline;
-            result.attachments = strideMatch->attachments;
-            return result;
-          }
-        }
-      }
-      // ─────────────────────────────────────────────────────────────────────────
-
-      const bool useAsync = async && m_device->config().enableAsync && env::getEnvVar("DXVK_ASYNC") != "0";
+            const bool useAsync = async && m_device->config().enableAsync && env::getEnvVar("DXVK_ASYNC") != "0";
 
       // Prevent other threads from adding new instances and check again
       std::unique_lock<dxvk::mutex> lock(useAsync ? m_asyncMutex : m_mutex);
-      instance = this->findInstance(state);
+      instance = this->findInstance(lookupState);
 
       if (!instance) {
         if (useAsync) {
           // When GPL is available, create a base instance immediately so that
           // m_pipelines is non-empty; subsequent variant misses above will then
           // find it via findStrideNormalisedInstance and avoid null handles.
-          if (this->canCreateBasePipeline(state)) {
-            instance = this->createInstance(state, /*doCreateBasePipeline=*/true);
+          if (this->canCreateBasePipeline(lookupState)) {
+            instance = this->createInstance(lookupState, /*doCreateBasePipeline=*/true);
             lock.unlock();
             m_async.store(true, std::memory_order_release);
-            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Normal);
+            m_workers->compileGraphicsPipeline(this, lookupState, DxvkPipelinePriority::High);
             return instance->getHandle();
           }
 
           m_async.store(true, std::memory_order_release);
           lock.unlock();
 
-          m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Normal);
+          m_workers->compileGraphicsPipeline(this, lookupState, DxvkPipelinePriority::High);
 
           return DxvkGraphicsPipelineHandle();
         }
 
         // Keep pipeline object locked, at worst we're going to stall
         // a state cache worker and the current thread needs priority.
-        bool canCreateBasePipeline = this->canCreateBasePipeline(state);
-        instance = this->createInstance(state, canCreateBasePipeline);
+        bool canCreateBasePipeline = this->canCreateBasePipeline(lookupState);
+        instance = this->createInstance(lookupState, canCreateBasePipeline);
 
         // Unlock here since we may dispatch the pipeline to a worker,
         // which will then acquire it to increment the use counter.
@@ -1215,12 +1139,12 @@ namespace dxvk {
 
         // If necessary, compile an optimized pipeline variant
         if (!instance->fastHandle.load())
-          m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Low);
+          m_workers->compileGraphicsPipeline(this, lookupState, DxvkPipelinePriority::Low);
 
         // Only store pipelines in the state cache that cannot benefit
         // from pipeline libraries, or if that feature is disabled.
         if (!canCreateBasePipeline)
-          this->writePipelineStateToCache(state, dynDs);
+          this->writePipelineStateToCache(lookupState, dynDs);
       }
     }
 

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1165,7 +1165,7 @@ namespace dxvk {
             // writePipelineStateToCache is also skipped: PR #81 normalises
             // strides to 0 on write, so the cache already contains this entry
             // from the initial preload.
-            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Normal);
+            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Low);
 
             DxvkGraphicsPipelineHandle result;
             result.handle      = standInHandle;
@@ -1192,14 +1192,14 @@ namespace dxvk {
             instance = this->createInstance(state, /*doCreateBasePipeline=*/true);
             lock.unlock();
             m_async.store(true, std::memory_order_release);
-            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::High);
+            m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Low);
             return instance->getHandle();
           }
 
           m_async.store(true, std::memory_order_release);
           lock.unlock();
 
-          m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::High);
+          m_workers->compileGraphicsPipeline(this, state, DxvkPipelinePriority::Low);
 
           return DxvkGraphicsPipelineHandle();
         }

--- a/src/dxvk/dxvk_graphics.h
+++ b/src/dxvk/dxvk_graphics.h
@@ -690,37 +690,7 @@ namespace dxvk {
       const DxvkGraphicsPipelineStateInfo& state,
       const DxvkDepthStencilState&         dynDs) const;
 
-    /**
-     * \brief Find a stride-normalised stand-in instance.
-     *
-     * dyasync principle (pythonlover02/DXVK-Sarek, old-main-dyasync):
-     *   On a variant miss caused solely by differing vertex binding strides,
-     *   use any already-compiled instance whose state matches after zeroing
-     *   all ilBinding strides as a temporary stand-in.
-     *
-     * Background:
-     *   PR #81 zeroes strides when writing to the state cache so that the
-     *   cache SHA-1 key is stable across draw calls.  After preload the
-     *   compiled instances in m_pipelines have stride=0 in their stored
-     *   state.  A live draw call that differs only in stride therefore
-     *   misses findInstance() even though the compiled pipeline is
-     *   functionally identical for pipelines using
-     *   VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE (useDynamicVertexStrides).
-     *
-     * Algorithm:
-     *   1. Check useDynamicVertexStrides() on the incoming live state -- only
-     *      these pipelines use dynamic strides so the stand-in is valid.
-     *   2. Copy live state, zero all ilBinding strides.
-     *   3. Call findInstance(normalisedState).
-     *   4. Return the matched instance (or nullptr if none compiled yet).
-     *
-     * \param [in] liveState  The exact state from the current draw call.
-     * \returns Pointer to an existing compiled instance, or nullptr.
-     */
-    DxvkGraphicsPipelineInstance* findStrideNormalisedInstance(
-      const DxvkGraphicsPipelineStateInfo& liveState);
-
-    void logPipelineState(
+        void logPipelineState(
             LogLevel                       level,
       const DxvkGraphicsPipelineStateInfo& state) const;
 

--- a/src/dxvk/dxvk_graphics.h
+++ b/src/dxvk/dxvk_graphics.h
@@ -690,6 +690,36 @@ namespace dxvk {
       const DxvkGraphicsPipelineStateInfo& state,
       const DxvkDepthStencilState&         dynDs) const;
 
+    /**
+     * \brief Find a stride-normalised stand-in instance.
+     *
+     * dyasync principle (pythonlover02/DXVK-Sarek, old-main-dyasync):
+     *   On a variant miss caused solely by differing vertex binding strides,
+     *   use any already-compiled instance whose state matches after zeroing
+     *   all ilBinding strides as a temporary stand-in.
+     *
+     * Background:
+     *   PR #81 zeroes strides when writing to the state cache so that the
+     *   cache SHA-1 key is stable across draw calls.  After preload the
+     *   compiled instances in m_pipelines have stride=0 in their stored
+     *   state.  A live draw call that differs only in stride therefore
+     *   misses findInstance() even though the compiled pipeline is
+     *   functionally identical for pipelines using
+     *   VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE (useDynamicVertexStrides).
+     *
+     * Algorithm:
+     *   1. Check useDynamicVertexStrides() on the incoming live state -- only
+     *      these pipelines use dynamic strides so the stand-in is valid.
+     *   2. Copy live state, zero all ilBinding strides.
+     *   3. Call findInstance(normalisedState).
+     *   4. Return the matched instance (or nullptr if none compiled yet).
+     *
+     * \param [in] liveState  The exact state from the current draw call.
+     * \returns Pointer to an existing compiled instance, or nullptr.
+     */
+    DxvkGraphicsPipelineInstance* findStrideNormalisedInstance(
+      const DxvkGraphicsPipelineStateInfo& liveState);
+
     void logPipelineState(
             LogLevel                       level,
       const DxvkGraphicsPipelineStateInfo& state) const;

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -4,7 +4,7 @@ namespace dxvk {
 
   DxvkOptions::DxvkOptions(const Config& config) {
     gplAsyncCache = config.getOption<bool>("dxvk.gplAsyncCache", true);
-    dyasyncStrideFallback = config.getOption<bool>("dxvk.dyasyncStrideFallback", true);
+    normaliseVertexStrides = config.getOption<bool>("dxvk.normaliseVertexStrides", true);
     enableAsync           = config.getOption<bool>    ("dxvk.enableAsync",            true);
     enableDebugUtils      = config.getOption<bool>    ("dxvk.enableDebugUtils",       false);
     enableStateCache      = config.getOption<bool>    ("dxvk.enableStateCache",       true);

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -4,6 +4,7 @@ namespace dxvk {
 
   DxvkOptions::DxvkOptions(const Config& config) {
     gplAsyncCache = config.getOption<bool>("dxvk.gplAsyncCache", true);
+    dyasyncStrideFallback = config.getOption<bool>("dxvk.dyasyncStrideFallback", true);
     enableAsync           = config.getOption<bool>    ("dxvk.enableAsync",            true);
     enableDebugUtils      = config.getOption<bool>    ("dxvk.enableDebugUtils",       false);
     enableStateCache      = config.getOption<bool>    ("dxvk.enableStateCache",       true);

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -38,23 +38,14 @@ namespace dxvk {
     // Enable state cache with gpl and fixes for async
     bool gplAsyncCache;
 
-    /// dyasync-style stride-normalised stand-in (default: true).
+    /// Normalise vertex binding strides to 0 before pipeline lookup (default: true).
     ///
-    /// When a live draw call misses findInstance() because its ilBinding strides
-    /// differ from the stride-0 entries stored by the state cache (PR #81 zeroes
-    /// strides on write), this option enables the following behaviour:
-    ///
-    ///   1. Zero the live strides to produce a normalised state.
-    ///   2. Call findInstance(normalisedState).
-    ///   3. If a compiled instance exists, return its handle immediately as a
-    ///      temporary stand-in (geometry is always visible, possible 1-frame
-    ///      visual difference -- same trade-off as dyasync in DXVK-Sarek).
-    ///   4. Queue the exact live-stride variant at High priority.
-    ///   5. When compilation finishes, future calls return the exact pipeline.
-    ///
-    /// Equivalent to dyasync FallbackMap in pythonlover02/DXVK-Sarek
-    /// (old-main-dyasync), adapted to the GPLALL stride-normalisation axis.
-    bool dyasyncStrideFallback;
+    /// When VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE is active, strides
+    /// are not baked into the VkPipeline object. The cache-preloaded instance
+    /// (stride=0, written by PR #81) IS the correct pipeline for any live
+    /// stride value. Normalising before findInstance() lets the preloaded
+    /// instance be found directly -- no recompile, no stand-in needed.
+    bool normaliseVertexStrides;
 
     /// Shader-related options
     Tristate useRawSsbo = Tristate::Auto;

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -38,6 +38,24 @@ namespace dxvk {
     // Enable state cache with gpl and fixes for async
     bool gplAsyncCache;
 
+    /// dyasync-style stride-normalised stand-in (default: true).
+    ///
+    /// When a live draw call misses findInstance() because its ilBinding strides
+    /// differ from the stride-0 entries stored by the state cache (PR #81 zeroes
+    /// strides on write), this option enables the following behaviour:
+    ///
+    ///   1. Zero the live strides to produce a normalised state.
+    ///   2. Call findInstance(normalisedState).
+    ///   3. If a compiled instance exists, return its handle immediately as a
+    ///      temporary stand-in (geometry is always visible, possible 1-frame
+    ///      visual difference -- same trade-off as dyasync in DXVK-Sarek).
+    ///   4. Queue the exact live-stride variant at High priority.
+    ///   5. When compilation finishes, future calls return the exact pipeline.
+    ///
+    /// Equivalent to dyasync FallbackMap in pythonlover02/DXVK-Sarek
+    /// (old-main-dyasync), adapted to the GPLALL stride-normalisation axis.
+    bool dyasyncStrideFallback;
+
     /// Shader-related options
     Tristate useRawSsbo = Tristate::Auto;
 


### PR DESCRIPTION
dyasync stride-normalised stand-in + gplasync compile path
Summary
Eliminates a class of pipeline miss events caused by the vertex binding stride normalisation introduced in PR #81, using the same dyasync principle as pythonlover02/DXVK-Sarek (old-main-dyasync): return a compiled pipeline from the state cache as a temporary stand-in while the exact variant is compiled asynchronously via the gplasync path.

Background
PR #81 zeroes all ilBinding strides before writing to the state cache so that the SHA-1 key is stable across draw calls. After preload, compiled instances in m_pipelines carry stride = 0 in their stored state. A live draw call with non-zero strides therefore misses findInstance() every time, even though the compiled VkPipeline is functionally valid — because the pipeline uses VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE, strides are not baked into the pipeline object and are applied by the command buffer at draw time.

Before this patch, those misses fell through to either:

The useAsync path → VK_NULL_HANDLE returned → geometry not rendered for the compilation window

The synchronous path → render thread stalled for the full compile duration

Both outcomes are visible to the player: the first as geometry pop-in, the second as a frame spike.

Changes
findStrideNormalisedInstance() (new method)
Scans m_pipelines for an instance whose state matches the live draw call after zeroing all ilBinding strides, mirroring the PR #81 write-side normalisation. Guard: only applied when liveState.useDynamicVertexStrides() == true, ensuring a baked-stride pipeline is never returned for a draw that requires a different baked stride.

getPipelineHandle() — dyasync stand-in block
Inserted before the useAsync path. When dyasyncStrideFallback = true and a stride-normalised match exists:

Returns the matched instance's fastHandle (or baseHandle) immediately as a stand-in — geometry is always rendered, no null handle.

Queues the exact live-stride variant at DxvkPipelinePriority::High via compileGraphicsPipeline().

When the worker finishes, fastHandle is stored in the new instance and future calls to findInstance(liveState) find it directly — the stand-in is no longer used.

If no normalised match exists yet (first draw, cold cache), falls through to the existing paths unchanged.

getPipelineHandle() — first-encounter upgrade (inside useAsync)
When GPL is available and no instance exists yet, createInstance(state, true) is called before dispatching the worker, so m_pipelines is immediately non-empty. Subsequent stride-variant misses can then find this base instance via findStrideNormalisedInstance and use it as a stand-in.

compilePipeline() — gplasync compile path fix
Previously createInstance(state, false) was always called in the worker path, producing a non-GPL monolithic instance even when gplAsyncCache or m_async was active. Fixed to:


bool useGplBase = (gplAsyncCache || m_async.load()) && canCreateBasePipeline(state);
instance = createInstance(state, useGplBase);

This ensures the exact live-stride variant is compiled with GPL: base pipeline fast-linked immediately, optimised variant compiled on top — matching the gplasync first-encounter behaviour in getPipelineHandle().

Attribution
Stand-in principle from pythonlover02/DXVK-Sarek, old-main-dyasync branch (findFallback / FallbackMap). Adapted to the GPLALL stride-normalisation axis: the stride-0 cache-preloaded instance is the "closest match" for any live draw whose state differs only in ilBindings[*].stride.